### PR TITLE
Bump jQuery.Validation from 1.17.0 to 1.19.3 in /POS.WebUI

### DIFF
--- a/POS.WebUI/packages.config
+++ b/POS.WebUI/packages.config
@@ -3,7 +3,7 @@
   <package id="Antlr" version="3.5.0.2" targetFramework="net472" />
   <package id="bootstrap" version="3.4.1" targetFramework="net472" />
   <package id="jQuery" version="3.4.1" targetFramework="net472" />
-  <package id="jQuery.Validation" version="1.17.0" targetFramework="net472" />
+  <package id="jQuery.Validation" version="1.19.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net472" />


### PR DESCRIPTION
Bumps jQuery.Validation from 1.17.0 to 1.19.3.

---
updated-dependencies:
- dependency-name: jQuery.Validation dependency-type: direct:production ...